### PR TITLE
Fix for year ranges

### DIFF
--- a/docembedder/utils.py
+++ b/docembedder/utils.py
@@ -134,7 +134,7 @@ class SimulationSpecification():
         """Year ranges for the simulation specification."""
         cur_start = self.year_start - ((self.year_start-STARTING_YEAR) % self.window_size)
         cur_end = self.year_start + self.window_size
-        while cur_start < self.year_end:
+        while cur_end <= self.year_end:
             yield list(range(cur_start, cur_end))
             cur_start += self.window_shift
             cur_end += self.window_shift


### PR DESCRIPTION
Can you check if this fixes the issue with the year ranges?

Note that the year ranges might only properly work when we have all consecutive years. `year_end` in the final runs should then be set to 1951 (considering that 1950 is the last proper patent year iirc). The same goes for the `year_start` not being before the first (consecutive) patent year.